### PR TITLE
Rewrite exercise to account for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ Prepare SQL statements while testing them on a local running database.
 
 ## To Do List Application
 
-Write all of your SQL statements in todo_app.sql
+Write these SQL statements in db_init.sql:
 
 1. Write a query to drop a database named `todo_app` if it exists
 1. Write a query to delete a user named `michael` if it exists
 1. Write a query to create a user named `michael` with an encrypted password `stonebreaker`
 1. Write a query to create a database named `todo_app`
-1. Connect to the newly created database
+
+Write these SQL statements in todo_app.sql, and run them against your newly created database:
+
 1. Write a query to create a table named `tasks` using the **Initial columns** detailed below
 1. Define column `id` as the table's primary key
 1. Write queries to accomplish the following


### PR DESCRIPTION
Basically since we're using docker now and trying to get to a point
where psql is not installed on the host laptop at all, the exercise
needs to be re-written to account for some lost of functionality.

The major difference is that we can't use the psql meta commands like
\c and \dt. The exercise was re-written to defer that to how the GUI
app itself rather than through code. I've also split the exercise
two files, one to setup the db, then once the user switches to the
right DB, the usual todo_app.sql file that contains the rest of the
queries.